### PR TITLE
Windows fix

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
     "update_url": "https://clients2.google.com/service/update2/crx",
     "name": "Last Two Tabs Toggler",
-    "version": "1.2.1",
+    "version": "1.2.2",
     "description": "Toggle between the two latest active tabs using Control+Space. Useful if you want to toggle between documentation and a admin panel. You have to have visited at least two tabs after loading the extension for this to work.",
     "manifest_version": 3,
     "icons": {
@@ -15,6 +15,8 @@
         "toggle_tabs": {
             "suggested_key": {
                 "default": "Ctrl+Space",
+                "windows": "Ctrl+Space",
+                "linux": "Ctrl+Space",
                 "mac": "MacCtrl+Space"
             },
             "description": "Toggle between the two latest active tabs."

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
     "update_url": "https://clients2.google.com/service/update2/crx",
     "name": "Last Two Tabs Toggler",
     "version": "1.2.2",
-    "description": "Toggle between the two latest active tabs using Control+Space. Useful if you want to toggle between documentation and a admin panel. You have to have visited at least two tabs after loading the extension for this to work.",
+    "description": "Toggle between the two latest active tabs using Control+Space.",
     "manifest_version": 3,
     "icons": {
         "16": "icons/16.png",


### PR DESCRIPTION
Specified Windows and Linux hotkey instead of relying on the default hotkey. Let's see if it fixes the bug where Chrome in Windows did not honor the suggested key from the manifest file.